### PR TITLE
Add copy option to optimize

### DIFF
--- a/mozjpeg_lossless_optimization/mozjpeg_opti.c
+++ b/mozjpeg_lossless_optimization/mozjpeg_opti.c
@@ -1,7 +1,13 @@
 #include <setjmp.h>
 #include "../mozjpeg/cdjpeg.h"
+#include "../mozjpeg/transupp.h"
 #include "./mozjpeg_opti.h"
 
+void jcopy_markers_setup(j_decompress_ptr srcinfo,
+    JCOPY_OPTION option);
+void jcopy_markers_execute(j_decompress_ptr srcinfo,
+      j_compress_ptr dstinfo,
+      JCOPY_OPTION option);
 
 struct custom_jpeg_error_mgr {
     struct jpeg_error_mgr pub;
@@ -23,7 +29,8 @@ void mozjpeg_lossless_optimization_emit_message(j_common_ptr cinfo, int msg_leve
 unsigned long mozjpeg_lossless_optimization(
     unsigned char *input_jpeg_bytes,
     unsigned long input_jpeg_length,
-    unsigned char **output_jpeg_bytes
+    unsigned char **output_jpeg_bytes,
+    int copyoption
 ) {
     // Initialize the JPEG decompression object with custom error handling
     struct jpeg_decompress_struct srcinfo;
@@ -34,6 +41,9 @@ unsigned long mozjpeg_lossless_optimization(
     cjsrcerr.pub.emit_message = &mozjpeg_lossless_optimization_emit_message;
 
     jpeg_create_decompress(&srcinfo);
+    
+    // Enable saving of extra markers that we want to copy
+    jcopy_markers_setup(&srcinfo, copyoption);
 
     // Initialize the JPEG compression object with default error handling
     struct jpeg_compress_struct dstinfo;
@@ -66,6 +76,10 @@ unsigned long mozjpeg_lossless_optimization(
     // Compress
     jpeg_copy_critical_parameters(&srcinfo, &dstinfo);
     jpeg_write_coefficients(&dstinfo, src_coef_arrays);
+    
+    // Copy to the output file any extra markers that we want to preserve */
+    jcopy_markers_execute(&srcinfo, &dstinfo, copyoption);
+
     jpeg_finish_compress(&dstinfo);
 
     // Cleanup

--- a/mozjpeg_lossless_optimization/mozjpeg_opti.h
+++ b/mozjpeg_lossless_optimization/mozjpeg_opti.h
@@ -1,7 +1,8 @@
 unsigned long mozjpeg_lossless_optimization(
     unsigned char *input_jpeg_bytes,
     unsigned long input_jpeg_length,
-    unsigned char **output_jpeg_bytes
+    unsigned char **output_jpeg_bytes,
+    int copyoption
 );
 
 void mozjpeg_lossless_optimization_free_bytes(unsigned char **bytes);

--- a/mozjpeg_lossless_optimization/mozjpeg_opti.py
+++ b/mozjpeg_lossless_optimization/mozjpeg_opti.py
@@ -1,16 +1,26 @@
 from ._mozjpeg_opti import lib, ffi
 
+_copy_opts = {
+    'none': 0,            # copy no optional markers
+    'comments': 1,        # copy only comment (COM) markers
+    'all': 2,             # copy all optional markers
+    'all_except_icc': 3,  # copy all optional markers except APP2
+    'icc': 4              # copy only ICC profile (APP2) markers
+}
 
-def optimize(input_jpeg_bytes):
+
+def optimize(input_jpeg_bytes, copy='none'):
     output_jpeg_bytes_p = ffi.new("unsigned char**")
     output_jpeg_bytes_p_gc = ffi.gc(
         output_jpeg_bytes_p, lib.mozjpeg_lossless_optimization_free_bytes
     )
+    copy_option = _copy_opts.get(copy, 0)
 
     output_jpeg_length = lib.mozjpeg_lossless_optimization(
         input_jpeg_bytes,
         len(input_jpeg_bytes),
         output_jpeg_bytes_p_gc,
+        copy_option
     )
 
     if output_jpeg_length == 0:

--- a/mozjpeg_lossless_optimization/mozjpeg_opti_build.py
+++ b/mozjpeg_lossless_optimization/mozjpeg_opti_build.py
@@ -8,17 +8,17 @@ _ROOT = os.path.abspath(os.path.dirname(__file__))
 _C_FILE = os.path.join(_ROOT, "mozjpeg_opti.c")
 _H_FILE = os.path.join(_ROOT, "mozjpeg_opti.h")
 if ccompiler.get_default_compiler() == "unix":
-    _LIBJPEG_STATIC_LIB = os.path.join(_ROOT, "..", "mozjpeg", "build", "libjpeg.a")
+    _LIBTURBOJPEG_STATIC_LIB = os.path.join(_ROOT, "..", "mozjpeg", "build", "libturbojpeg.a")
 elif ccompiler.get_default_compiler() == "msvc":
-    _LIBJPEG_STATIC_LIB = os.path.join(
-        _ROOT, "..", "mozjpeg", "build", "Release", "jpeg-static.lib"
+    _LIBTURBOJPEG_STATIC_LIB = os.path.join(
+        _ROOT, "..", "mozjpeg", "build", "Release", "turbojpeg-static.lib"
     )
 
 ffibuilder = FFI()
 ffibuilder.set_source(
     "mozjpeg_lossless_optimization._mozjpeg_opti",
     open(_C_FILE, "r").read(),
-    extra_objects=[_LIBJPEG_STATIC_LIB],
+    extra_objects=[_LIBTURBOJPEG_STATIC_LIB],
     include_dirs=[
         _ROOT,
         os.path.join(_ROOT, "..", "mozjpeg"),

--- a/tests/test_mozjpeg_opti.py
+++ b/tests/test_mozjpeg_opti.py
@@ -29,3 +29,7 @@ class Test_optimize(object):
     def test_optimize_raise_error_with_invalid_input_data(self):
         with pytest.raises(ValueError):
             mozjpeg_lossless_optimization.optimize(b"foobar")
+
+    def test_optimize_with_copy(self, image_bytes):
+        result = mozjpeg_lossless_optimization.optimize(image_bytes, copy='all')
+        assert result.startswith(b"\xFF\xD8\xFF\xE0\x00\x10JFIF")


### PR DESCRIPTION
Hello :wave:

This PR adds support for an optional `copy` parameter to `optimize`, which allows the library to preserve image metadata.

It now links to libturbojpeg instead of libjpeg because the `jcopy_markers_` functions are not exported in libjpeg.

I hope this can be useful to others 🙏 

Closes #4 